### PR TITLE
Fix typo

### DIFF
--- a/es/translation.json
+++ b/es/translation.json
@@ -5,7 +5,7 @@
   "downloads": "descargas",
   "404 This Page not Found": "404 Página no encontrada :/",
   "Click to go to the main page of deskreen.com": "Clic para ir a la página principal de deskreen.com",
-  "Turn any device into a secondary screen for your computer": "Converte cualquier dispositivo en una pantalla secundaria para tu computadora",
+  "Turn any device into a secondary screen for your computer": "Convierte cualquier dispositivo en una pantalla secundaria para tu computadora",
   "Privacy Policy": "Política de privacidad",
   "Go Back to Main Page": "Regresar a la página principal",
   "Deskreen privacy policy": "Política de privacidad de Deskreen",


### PR DESCRIPTION
Fixes a little typo on the Spanish resources: "Converte" --> "Convierte"